### PR TITLE
rsetsockopt: fix bit manipulation

### DIFF
--- a/src/rsocket.c
+++ b/src/rsocket.c
@@ -3507,9 +3507,9 @@ int rsetsockopt(int socket, int level, int optname,
 
 	if (!ret && opts) {
 		if (opt_on)
-			*opts |= (1 << optname);
+			*opts |= (1ULL << optname);
 		else
-			*opts &= ~(1 << optname);
+			*opts &= ~(1ULL << optname);
 	}
 
 	return ret;


### PR DESCRIPTION
I'm not sure if the upper bits are actually used now, but anyway, it might happen in future.
rsetsockopt was unable to set/clear bits properly which position is >= 32.
Moreover, any clear bit operation clears also upper bits (32-63).

Found using static analysis tool PVS-Studio.